### PR TITLE
Added Flipped Hybrid Screen Layout

### DIFF
--- a/src/frontend/FrontendUtil.h
+++ b/src/frontend/FrontendUtil.h
@@ -34,6 +34,7 @@ namespace Frontend
 //     1 = vertical
 //     2 = horizontal
 //     3 = hybrid
+//     4 = flipped hybrid
 // * rotation: angle at which the DS screens are presented: 0/1/2/3 = 0/90/180/270
 // * sizing: how the display size is shared between the two screens
 //     0 = even (both screens get same size)

--- a/src/frontend/qt_sdl/main.cpp
+++ b/src/frontend/qt_sdl/main.cpp
@@ -876,7 +876,14 @@ QSize ScreenHandler::screenGetMinSize(int factor = 1)
         else
             return QSize(w+gap+w, h);
     }
-    else // hybrid
+    else if (Config::ScreenLayout == 3) // hybrid
+    {
+        if (isHori)
+            return QSize(h+gap+h, 3*w + (int)ceil((4*gap) / 3.0));
+        else
+            return QSize(3*w + (int)ceil((4*gap) / 3.0), h+gap+h);
+    }
+    else // flipped hybrid
     {
         if (isHori)
             return QSize(h+gap+h, 3*w + (int)ceil((4*gap) / 3.0));
@@ -1641,9 +1648,9 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent)
             QMenu* submenu = menu->addMenu("Screen layout");
             grpScreenLayout = new QActionGroup(submenu);
 
-            const char* screenlayout[] = {"Natural", "Vertical", "Horizontal", "Hybrid"};
+            const char* screenlayout[] = {"Natural", "Vertical", "Horizontal", "Hybrid", "Flipped Hybrid"};
 
-            for (int i = 0; i < 4; i++)
+            for (int i = 0; i < 5; i++)
             {
                 actScreenLayout[i] = submenu->addAction(QString(screenlayout[i]));
                 actScreenLayout[i]->setActionGroup(grpScreenLayout);
@@ -3280,7 +3287,7 @@ int main(int argc, char** argv)
     SANITIZE(Config::MicInputType, 0, (int)micInputType_MAX);
     SANITIZE(Config::ScreenRotation, 0, 3);
     SANITIZE(Config::ScreenGap, 0, 500);
-    SANITIZE(Config::ScreenLayout, 0, 3);
+    SANITIZE(Config::ScreenLayout, 0, 4);
     SANITIZE(Config::ScreenSizing, 0, (int)screenSizing_MAX);
     SANITIZE(Config::ScreenAspectTop, 0, 4);
     SANITIZE(Config::ScreenAspectBot, 0, 4);

--- a/src/frontend/qt_sdl/main.h
+++ b/src/frontend/qt_sdl/main.h
@@ -408,7 +408,7 @@ public:
     QActionGroup* grpScreenGap;
     QAction* actScreenGap[6];
     QActionGroup* grpScreenLayout;
-    QAction* actScreenLayout[4];
+    QAction* actScreenLayout[5];
     QAction* actScreenSwap;
     QActionGroup* grpScreenSizing;
     QAction* actScreenSizing[6];


### PR DESCRIPTION
This commit added the "Flipped Hybrid" option to the screen layout options. It is similar to the "Hybrid" option but moves the large screen to the right and the two smaller screens to the left.
This feature will help for people who are right-handed using a touch screen on Steam Decks or similar devices. It works with all four rotations, swap screen option, and touch functionality.

Hybrid Layout:
![Screenshot 2023-06-20 233722](https://github.com/HetchBug/melonDS/assets/12724979/e182d0c2-a2e3-405b-a8b9-9b9e5e454270)

Flipped Hybrid Layout:
![Screenshot 2023-06-20 233735](https://github.com/HetchBug/melonDS/assets/12724979/063cc96a-906b-4374-bcd8-de3002814c7f)